### PR TITLE
Export crashdump path and dump db in crashdump

### DIFF
--- a/actions/juju-k8s-crashdump/action.yaml
+++ b/actions/juju-k8s-crashdump/action.yaml
@@ -10,11 +10,18 @@ inputs:
     required: true
   output_path:
     description: "Path to write the crashdump to, will write it as a .tar.gz file"
-    required: true
+    required: false
+    default: "juju-logs.tar.gz"
   proxy:
     description: "url for the a proxy to connect to pip with"
     required: false
     default: ""
+
+outputs:
+  crashdump_path:
+    description: "Path to the output crashdump"
+    value: ${{ steps.collect_logs.outputs.crashdump_path }}
+
 runs:
   using: "composite"
   steps:
@@ -23,12 +30,14 @@ runs:
     with:
       repository: canonical/juju-k8s-crashdump
       path: ./juju-k8s-crashdump
-  - name: install pipx
+
+  - name: Install pipx
     shell: bash
     working-directory: ./juju-k8s-crashdump
     run: |
       sudo apt-get update --quiet
       sudo apt-get install pipx --quiet --assume-yes
+
   - name: Setup pip proxy
     if: ${{inputs.proxy}} != ""
     shell: bash
@@ -40,6 +49,7 @@ runs:
       [global]
       proxy=${proxy}
       EOF
+
   - name: Install
     shell: bash
     working-directory: ./juju-k8s-crashdump
@@ -47,7 +57,9 @@ runs:
       sudo snap install kubectl --classic
       pipx install poetry==1.6
       pipx install .
+
   - name: Collect Logs
+    id: collect_logs
     shell: bash
     working-directory: ./juju-k8s-crashdump
     env:
@@ -55,4 +67,6 @@ runs:
       controller: ${{ inputs.controller }}
       output_path: ${{ inputs.output_path }}
     run: |
-      juju-k8s-crashdump ${kubeconf} ${controller} --output ${output_path}
+      juju-k8s-crashdump "${kubeconf}" "${controller}" --output "${output_path}"
+      echo "crashdump_path=$(realpath ${output_path})" >> $GITHUB_OUTPUT
+

--- a/juju_k8s_crashdump/cmd/cmd.py
+++ b/juju_k8s_crashdump/cmd/cmd.py
@@ -31,10 +31,10 @@ class CmdError(RuntimeError):
 
 
 class CmdClient:
-    def call(self, *args: list[CmdArg]) -> str:
+    def call(self, *args: list[CmdArg], environment: dict[str, str] | None = None) -> str:
         # Run the command
         parsed_args = self.parse_args(*args)
-        result = subprocess.run(self.parse_args(*args), capture_output=True, text=True)
+        result = subprocess.run(self.parse_args(*args), capture_output=True, text=True, env=environment)
 
         # Print the results
         # print(result.stdout, end="")

--- a/juju_k8s_crashdump/juju/client.py
+++ b/juju_k8s_crashdump/juju/client.py
@@ -20,3 +20,7 @@ class JujuClient(ABC):
     @abstractmethod
     def bundle_string(self, controller: str, model: str) -> str:
         raise NotImplementedError
+
+    @abstractmethod
+    def dump_db(self, controller: str, model: str, format: str = "yaml") -> str:
+        raise NotImplementedError

--- a/juju_k8s_crashdump/juju_cmd/client.py
+++ b/juju_k8s_crashdump/juju_cmd/client.py
@@ -14,8 +14,8 @@ class JujuCmdClient(JujuClient):
     def __init__(self, cmd_client: CmdClient = None):
         self.cmd_client = cmd_client if cmd_client is not None else CmdClient()
 
-    def _call_juju(self, *args: list[CmdArg]) -> str:
-        return self.cmd_client.call(CmdArg(value="juju"), *args)
+    def _call_juju(self, *args: list[CmdArg], environment: dict[str, str] | None = None) -> str:
+        return self.cmd_client.call(CmdArg(value="juju"), *args, environment=environment)
 
     def models(self, controller: str) -> list[str]:
         return [
@@ -50,4 +50,12 @@ class JujuCmdClient(JujuClient):
         return self._call_juju(
             CmdArg(value="export-bundle"),
             CmdArg(name="model", value=f"{controller}:{model}"),
+        )
+
+    def dump_db(self, controller: str, model: str, format: str = "yaml") -> str:
+        return self._call_juju(
+            CmdArg(value="dump-db"),
+            CmdArg(name="model", value=f"{controller}:{model}"),
+            CmdArg(name="format", value=format),
+            environment={"JUJU_DEV_FEATURE_FLAGS": "developer-mode"},
         )

--- a/juju_k8s_crashdump/main.py
+++ b/juju_k8s_crashdump/main.py
@@ -65,6 +65,8 @@ def write_juju_model_info_to_file(juju_client: JujuClient, controller: str, mode
         except Exception as e:
             bundle_string = str(e)
         f.write(bundle_string)
+    with open(f"{path}/db-dump.yaml", "w+") as f:
+        f.write(juju_client.dump_db(controller, model, format="yaml"))
 
 
 def os_mkdir(path: str):


### PR DESCRIPTION
# Description

I figured that the dump db would be better put in the crashdump.

Additionally, export the crashdump path as an output in the action.

# Resolved issues

- What issues are resolved by this PR? Necessary support for https://github.com/canonical/charm-integration-testing/pull/54
- What may help in reviewing it?

## Documentation

- Is documentation (including README) covering your changes up to date?

## Tests

- How were these changes tested? Are there automated tests for anything that is readily testable?
- What should the reviewer do to test, if it's credibly locally testable? (Why is it not, if it
  isn't?)
