### PR TITLE
Ensure existing environment variables are included

### DIFF
--- a/actions/juju-k8s-crashdump/action.yaml
+++ b/actions/juju-k8s-crashdump/action.yaml
@@ -30,6 +30,9 @@ runs:
     with:
       repository: canonical/juju-k8s-crashdump
       path: ./juju-k8s-crashdump
+      ref: ${{ env.ACTION_REF }}
+    env:
+      ACTION_REF: ${{ github.action_ref }}
 
   - name: Install pipx
     shell: bash

--- a/juju_k8s_crashdump/cmd/cmd.py
+++ b/juju_k8s_crashdump/cmd/cmd.py
@@ -1,6 +1,7 @@
 # Copyright 2025 Canonical Ltd.
 # See LICENSE file for licensing details.
 
+import os
 import subprocess
 import sys
 from typing import Optional
@@ -32,6 +33,10 @@ class CmdError(RuntimeError):
 
 class CmdClient:
     def call(self, *args: list[CmdArg], environment: dict[str, str] | None = None) -> str:
+        # Copy existing environment if environment is passed
+        if environment is not None:
+            environment = {**os.environ.copy(), **environment}
+
         # Run the command
         parsed_args = self.parse_args(*args)
         result = subprocess.run(self.parse_args(*args), capture_output=True, text=True, env=environment)


### PR DESCRIPTION
# Description

The passed in environment variables completely overwrites the existing environment :facepalm: 

Also checks out the action branch rather than `main`

# Resolved issues

- What issues are resolved by this PR? Juju crashdump will now succeed at dumping the juju database.
- What may help in reviewing it?

## Documentation

- Is documentation (including README) covering your changes up to date?

## Tests

- How were these changes tested? [Sample run](https://github.com/canonical/charm-integration-testing/actions/runs/14446358428/job/40507787565)
