### PR TITLE
Retry commands if they fail

### DIFF
--- a/juju_k8s_crashdump/main.py
+++ b/juju_k8s_crashdump/main.py
@@ -5,9 +5,10 @@
 import argparse
 import os
 import tarfile
-from datetime import datetime
+from datetime import datetime, timedelta
 from tempfile import TemporaryDirectory
 
+from .cmd import CmdClient
 from .juju import JujuClient
 from .juju_cmd import JujuCmdClient
 from .k8s import KubectlClient
@@ -82,8 +83,9 @@ def write_tar(tar_path: str, directory: str):
 def main():
     parser = create_parser()
     args = parser.parse_args()
-    juju_client = JujuCmdClient()
-    kubectl_client = KubectlCmdClient(args.kubeconf)
+    cmd_client = CmdClient(retry_count=5, retry_delay=timedelta(seconds=5))
+    juju_client = JujuCmdClient(cmd_client=cmd_client)
+    kubectl_client = KubectlCmdClient(args.kubeconf, cmd_client=cmd_client)
     with TemporaryDirectory() as tempdir:
         write_kubernetes_version_to_file(kubectl_client, tempdir)
         for namespace in get_namespaces(juju_client, args.controller):


### PR DESCRIPTION
# Description

Sometimes commands things fail

```
juju_k8s_crashdump.cmd.cmd.CmdError: Command 'kubectl --kubeconfig  describe pvc loki-k8s-loki-chunks-cf1a6324-loki-k8s-0 --namespace model-18951406276-251030183716' exited with return code '1', stderr: Error from server: etcdserver: leader changed
```

When commands fail, retry them.

# Resolved issues

- What issues are resolved by this PR? Commands fail when a retry will probably fix them.
- What may help in reviewing it?

## Documentation

N/A

## Tests

Tested locally, crashdump is still collected.
