### PR TITLE
Collect var logs using `kubectl cp`

### DIFF
--- a/juju_k8s_crashdump/cmd/__init__.py
+++ b/juju_k8s_crashdump/cmd/__init__.py
@@ -3,4 +3,4 @@
 
 from .cmd import CmdArg, CmdClient, CmdError
 
-__all__ = [CmdArg, CmdClient, CmdError]
+__all__ = ["CmdArg", "CmdClient", "CmdError"]

--- a/juju_k8s_crashdump/cmd/cmd.py
+++ b/juju_k8s_crashdump/cmd/cmd.py
@@ -40,7 +40,7 @@ class CmdClient:
         self.retry_count = retry_count
         self.retry_delay = retry_delay
 
-    def call(self, *args: list[CmdArg], environment: dict[str, str] | None = None) -> str:
+    def call(self, *args: CmdArg, environment: dict[str, str] | None = None) -> str:
         # Copy existing environment if environment is passed
         if environment is not None:
             environment = {**os.environ.copy(), **environment}
@@ -62,7 +62,7 @@ class CmdClient:
 
         return result.stdout
 
-    def parse_args(self, *args: list[CmdArg]) -> list[str]:
+    def parse_args(self, *args: CmdArg) -> list[str]:
         results = []
         for arg in args:
             if arg.name is not None:

--- a/juju_k8s_crashdump/juju/__init__.py
+++ b/juju_k8s_crashdump/juju/__init__.py
@@ -3,4 +3,4 @@
 
 from .client import JujuClient
 
-__all__ = [JujuClient]
+__all__ = ["JujuClient"]

--- a/juju_k8s_crashdump/juju/client.py
+++ b/juju_k8s_crashdump/juju/client.py
@@ -30,3 +30,7 @@ class JujuClient(ABC):
         self, controller: str, model: str, entity_type: str, entity_name: str, format: str = "tabular"
     ) -> str:
         raise NotImplementedError
+
+    @abstractmethod
+    def storage_string(self, controller: str, model: str, format: str = "tabular") -> str:
+        raise NotImplementedError

--- a/juju_k8s_crashdump/juju_cmd/__init__.py
+++ b/juju_k8s_crashdump/juju_cmd/__init__.py
@@ -3,4 +3,4 @@
 
 from .client import JujuCmdClient
 
-__all__ = [JujuCmdClient]
+__all__ = ["JujuCmdClient"]

--- a/juju_k8s_crashdump/juju_cmd/client.py
+++ b/juju_k8s_crashdump/juju_cmd/client.py
@@ -70,3 +70,10 @@ class JujuCmdClient(JujuClient):
             CmdArg(name="model", value=f"{controller}:{model}"),
             CmdArg(value=entity_name),
         )
+
+    def storage_string(self, controller: str, model: str, format: str = "tabular") -> str:
+        return self._call_juju(
+            CmdArg(value="storage"),
+            CmdArg(name="model", value=f"{controller}:{model}"),
+            CmdArg(name="format", value=format),
+        )

--- a/juju_k8s_crashdump/juju_cmd/client.py
+++ b/juju_k8s_crashdump/juju_cmd/client.py
@@ -11,10 +11,10 @@ from juju_k8s_crashdump.juju import JujuClient
 class JujuCmdClient(JujuClient):
     cmd_client: CmdClient
 
-    def __init__(self, cmd_client: CmdClient = None):
+    def __init__(self, cmd_client: CmdClient | None = None):
         self.cmd_client = cmd_client if cmd_client is not None else CmdClient()
 
-    def _call_juju(self, *args: list[CmdArg], environment: dict[str, str] | None = None) -> str:
+    def _call_juju(self, *args: CmdArg, environment: dict[str, str] | None = None) -> str:
         return self.cmd_client.call(CmdArg(value="juju"), *args, environment=environment)
 
     def models(self, controller: str) -> list[str]:

--- a/juju_k8s_crashdump/k8s/__init__.py
+++ b/juju_k8s_crashdump/k8s/__init__.py
@@ -3,4 +3,4 @@
 
 from .client import KubectlClient
 
-__all__ = [KubectlClient]
+__all__ = ["KubectlClient"]

--- a/juju_k8s_crashdump/k8s/client.py
+++ b/juju_k8s_crashdump/k8s/client.py
@@ -2,6 +2,7 @@
 # See LICENSE file for licensing details.
 
 from abc import ABC, abstractmethod
+from pathlib import Path
 
 
 class KubectlClient(ABC):
@@ -15,6 +16,10 @@ class KubectlClient(ABC):
 
     @abstractmethod
     def pod_logs(self, namespace: str, name: str) -> str:
+        raise NotImplementedError
+
+    @abstractmethod
+    def pod_cp(self, namespace: str, name: str, source: Path, destination: Path) -> str:
         raise NotImplementedError
 
     @abstractmethod

--- a/juju_k8s_crashdump/k8s_cmd/__init__.py
+++ b/juju_k8s_crashdump/k8s_cmd/__init__.py
@@ -3,4 +3,4 @@
 
 from .client import KubectlCmdClient
 
-__all__ = [KubectlCmdClient]
+__all__ = ["KubectlCmdClient"]

--- a/juju_k8s_crashdump/k8s_cmd/client.py
+++ b/juju_k8s_crashdump/k8s_cmd/client.py
@@ -12,11 +12,11 @@ class KubectlCmdClient(KubectlClient):
     cmd_client: CmdClient
     kubeconf: str
 
-    def __init__(self, kubeconf, cmd_client: CmdClient = None):
+    def __init__(self, kubeconf, cmd_client: CmdClient | None = None):
         self.kubeconf = kubeconf
         self.cmd_client = cmd_client if cmd_client is not None else CmdClient()
 
-    def _call_kubectl(self, *args: list[CmdArg]) -> str:
+    def _call_kubectl(self, *args: CmdArg) -> str:
         return self.cmd_client.call(CmdArg(value="kubectl"), CmdArg(value=self.kubeconf, name="kubeconfig"), *args)
 
     def get_resources(self, namespace: str, resource: str) -> list[str]:

--- a/juju_k8s_crashdump/k8s_cmd/client.py
+++ b/juju_k8s_crashdump/k8s_cmd/client.py
@@ -1,6 +1,7 @@
 # Copyright 2025 Canonical Ltd.
 # See LICENSE file for licensing details.
 
+from pathlib import Path
 
 import yaml
 
@@ -47,6 +48,14 @@ class KubectlCmdClient(KubectlClient):
             CmdArg(value=namespace, name="namespace"),
             CmdArg(name="all-containers"),
             CmdArg(name="ignore-errors"),
+        )
+
+    def pod_cp(self, namespace: str, name: str, source: Path, destination: Path) -> str:
+        return self._call_kubectl(
+            CmdArg(value="cp"),
+            CmdArg(value=namespace, name="namespace"),
+            CmdArg(value=f"{name}:{source}"),
+            CmdArg(value=str(destination)),
         )
 
     def version_info_string(self, format: str | None = None) -> str:

--- a/juju_k8s_crashdump/main.py
+++ b/juju_k8s_crashdump/main.py
@@ -56,6 +56,16 @@ def write_resource_info_to_file(kubectl_client: KubectlClient, namespace: str, r
             with open(path / f"{name}.log", "w+") as f:
                 f.write(kubectl_client.pod_logs(namespace, name))
 
+            source = Path("/var/log")
+            destination = path / f"{name}-var-log"
+            with open(f"{destination}.out", "w+") as f:
+                try:
+                    # only from the default container
+                    out = kubectl_client.pod_cp(namespace, name, source, destination)
+                except Exception as e:
+                    out = str(e)
+                f.write(out)
+
 
 def write_juju_model_info_to_file(juju_client: JujuClient, controller: str, model: str, path: Path):
     with open(path / "juju-status.txt", "w+") as f:

--- a/juju_k8s_crashdump/main.py
+++ b/juju_k8s_crashdump/main.py
@@ -94,6 +94,9 @@ def write_juju_model_info_to_file(juju_client: JujuClient, controller: str, mode
     with open(path / "db-dump.yaml", "w+") as f:
         f.write(juju_client.dump_db(controller, model, format="yaml"))
 
+    with open(path / "juju-storage.yaml", "w+") as f:
+        f.write(juju_client.storage_string(controller, model, format="yaml"))
+
     # status logs are written into the status-log directory as such:
     # status-log/
     #   ├── application-<app-name>.txt


### PR DESCRIPTION
# Description

Per the discussion in the original issue: https://github.com/canonical/charm-integration-testing/issues/258#issuecomment-3817902137 ...

- Add new command to run `kubectl cp` and use it to collect `/var/log` directory for each pod.
  - Currently only the contents from the default container is collected, which is the `charm` container as observed so far.
  - `kubectl cp` will copy the entire directory contents, so we can only provide it with a destination to write to ... but we do keep track of the command's output which can point to any errors or failures, e.g. missing `tar` command in container.
  - > **NOTE**
    > If the charm-under-test (usually `target`) is successfully torn-down in the test, no var-logs will be collected for it, similar to why other pod-related things are not collected for it.
    >
    > But this may not be a problem, because we reach the tear-down only if all tests pass, and it is unlikely we need the logs then.
- Add new command to run `juju storage` and use it to collect a `yaml` with the storage information from Juju.  Can help debug situation where storage requests are stuck in pending.
- Also fixed many minor type-annotations issues ... sorry for the noise ... it's only in the first commit.

# Resolved issues

- Main part of fixing [TS-125](https://warthogs.atlassian.net/browse/TS-125)

## Documentation

- Is documentation (including README) covering your changes up to date?
  - No changes to README.md

## Tests

- How were these changes tested? Are there automated tests for anything that is readily testable?
  - Manual [run](https://github.com/canonical/charm-integration-testing/actions/runs/21518618616/) and confirming that `var-log` directories exist for remaining pods


[TS-125]: https://warthogs.atlassian.net/browse/TS-125?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ